### PR TITLE
[bugfix] new TransitionDrawable memory leak

### DIFF
--- a/dali/src/main/java/at/favre/lib/dali/builder/blur/BlurBuilder.java
+++ b/dali/src/main/java/at/favre/lib/dali/builder/blur/BlurBuilder.java
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.os.Build;
 import android.os.Handler;
@@ -287,8 +288,14 @@ public class BlurBuilder extends ABuilder {
                             if (data.alphaFadeIn) {
                                 //use what is currently in the imageview to fade
                                 Drawable placeholder;
-                                if (imageView.getDrawable() != null) {
-                                    placeholder = imageView.getDrawable();
+                                Drawable oldDrawable = imageView.getDrawable();
+                                if (oldDrawable != null) {
+                                    if (oldDrawable instanceof LayerDrawable) {
+                                        LayerDrawable oldLayerDrawable = (LayerDrawable) oldDrawable;
+                                        placeholder = oldLayerDrawable.getDrawable(0);
+                                    } else {
+                                        placeholder = imageView.getDrawable();
+                                    }
                                 } else {
                                     placeholder = new ColorDrawable(Color.parseColor("#00FFFFFF"));
                                 }


### PR DESCRIPTION
[bugfix] new TransitionDrawable point to old drawable array, which cause memory leak

As we know, TransitionDrawable is a LayerDrawable which contains a array of two drawables need to do transition.  But directly use old drawable to create new TransitionDrawable, let the the newly created TransitionDrawable hold a reference to the old array rather than the only drawable. 
```
placeholder = imageView.getDrawable();
```
So I break the reference chain and fix like this:
```
                                Drawable oldDrawable = imageView.getDrawable();
                                if (oldDrawable != null) {
                                    if (oldDrawable instanceof LayerDrawable) {
                                        LayerDrawable oldLayerDrawable = (LayerDrawable) oldDrawable;
                                        placeholder = oldLayerDrawable.getDrawable(0);
                                    } else {
                                        placeholder = imageView.getDrawable();
                                    }
                                } 
```

Please review that, and I hope you may accept this pr. 